### PR TITLE
OTP Validation Fails When Using DefaultCodeGenerator Without Parameters

### DIFF
--- a/spring-boot-3-jwt-security/src/main/java/com/alibou/security/tfa/TwoFactorAuthenticationService.java
+++ b/spring-boot-3-jwt-security/src/main/java/com/alibou/security/tfa/TwoFactorAuthenticationService.java
@@ -49,7 +49,7 @@ public class TwoFactorAuthenticationService {
 
     public boolean isOtpValid(String secret, String code) {
         TimeProvider timeProvider = new SystemTimeProvider();
-        CodeGenerator codeGenerator = new DefaultCodeGenerator();
+        CodeGenerator codeGenerator = new DefaultCodeGenerator(HashingAlgorithm.SHA1, 6);
         CodeVerifier verifier = new DefaultCodeVerifier(codeGenerator, timeProvider);
         return verifier.isValidCode(secret, code);
     }


### PR DESCRIPTION
# Description:
- This pull request addresses an issue in the TwoFactorAuthenticationService class, specifically in the isOtpValid method. The current implementation initializes the CodeGenerator without parameters, which causes OTP validation to fail when using the secret generated for the QR code.

## Changes Made:
- Updated the initialization of the CodeGenerator in the isOtpValid method to include the same hashing algorithm and digit count used during QR code generation. This ensures consistency between the OTP generation and validation processes.